### PR TITLE
Revised GT2560 pin files

### DIFF
--- a/Marlin/src/lcd/language/language_vi.h
+++ b/Marlin/src/lcd/language/language_vi.h
@@ -438,5 +438,4 @@ namespace Language_vi {
   LSTR MSG_SHORT_DAY                      = _UxGT("n");                                   // d - ngày - One character only
   LSTR MSG_SHORT_HOUR                     = _UxGT("g");                                   // h - giờ  - One character only
   LSTR MSG_SHORT_MINUTE                   = _UxGT("p");                                   // m - phút - One character only
-  LSTR MSG_SHORT_MINUTE                   = _UxGT("p");                                   // M - phút - One character only
 }

--- a/Marlin/src/pins/mega/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_A.h
@@ -101,6 +101,10 @@
 // Misc. Functions
 //
 
+//Power monitoring pins - set to 0 for main VIN, 1 for dedicated bed supply rail.
+//Don't forget to enable POWER_MONITOR_VOLTAGE in Configuration_adv.h set POWER_MONITOR_VOLTS_PER_VOLT to 0.090909
+#define POWER_MONITOR_VOLTAGE_PIN             0
+
 /**           LCD Header
  *              ------
  *          5V | 1  2 | GND
@@ -128,10 +132,6 @@
 
 #define SDSS                                  53
 #define LED_PIN                               13
-
-//Power monitoring pins - set to 0 for main VIN, 1 for dedicated bed supply rail.
-//Don't forget to enable POWER_MONITOR_VOLTAGE in Configuration_adv.h set POWER_MONITOR_VOLTS_PER_VOLT to 0.090909
-#define POWER_MONITOR_VOLTAGE_PIN             0
 
 #if HAS_WIRED_LCD
 

--- a/Marlin/src/pins/mega/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_A.h
@@ -47,14 +47,12 @@
 #define Y_MAX_PIN                             28
 #define Z_MIN_PIN                             30
 
-#if ENABLED(BLTOUCH)
-  #if MB(GT2560_REV_A_PLUS)
-    #define SERVO0_PIN                        11
-    #define Z_MAX_PIN                         32
-  #else
-    #define SERVO0_PIN                        32
-    #define Z_MAX_PIN                         -1
-  #endif
+#if ENABLED(BLTOUCH) && !defined(SERVO0_PIN)
+  #define SERVO0_PIN                          32
+#endif
+
+#if SERVO0_PIN == 32
+  #define Z_MAX_PIN                           -1
 #else
   #define Z_MAX_PIN                           32
 #endif
@@ -102,11 +100,35 @@
 //
 // Misc. Functions
 //
+
+/**           LCD Header
+ *              ------
+ *          5V | 1  2 | GND
+ *           6 | 3  4 | 5
+ *    (SCL) 21   5  6 | 16 (TX2)
+ *    (SDA) 20 | 7  8 | 17 (RX2)
+ *    (RX1) 19 | 9 10 | 18 (TX1)
+ *              ------
+ *               SV1
+ *
+ *          SDCARD Header
+ *              ------
+ *      5V/3V3 | 1  2 | GND
+ *       RESET | 3  4 | 38
+ *   (MOSI) 51   5  6 | 40
+ *     (SS) 53 | 7  8 | 42
+ *    (SCK) 52 | 9 10 | 50 (MISO)
+ *              ------
+ *               SV3
+ *
+ * GT2560 LCD & SD headers follow typical EXP1 & EXP2 format.
+ * SD header voltage pin set by link pads beneath the header; R25 for 5V, R44 for 3.3V (default)
+ * Pins 20 (SDA) and 21 (SCL) have external 10K pull-ups on the board.
+ */
+
 #define SDSS                                  53
 #define LED_PIN                               13
-#define PS_ON_PIN                             12
-#define SUICIDE_PIN                           54  // Must be enabled at startup to keep power flowing
-#define KILL_PIN                              -1
+#define POWER_MONITOR_VOLTAGE_PIN             0 // 0 for main, 1 for dedicated bed supply
 
 #if HAS_WIRED_LCD
 

--- a/Marlin/src/pins/mega/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_A.h
@@ -101,90 +101,99 @@
 // Misc. Functions
 //
 
-//Power monitoring pins - set to 0 for main VIN, 1 for dedicated bed supply rail.
-//Don't forget to enable POWER_MONITOR_VOLTAGE in Configuration_adv.h set POWER_MONITOR_VOLTS_PER_VOLT to 0.090909
+// Power monitoring pins - set to 0 for main VIN, 1 for dedicated bed supply rail.
+// Don't forget to enable POWER_MONITOR_VOLTAGE in Configuration_adv.h
+// and set POWER_MONITOR_VOLTS_PER_VOLT to 0.090909.
 #define POWER_MONITOR_VOLTAGE_PIN             0
 
-/**           LCD Header
- *              ------
- *          5V | 1  2 | GND
- *           6 | 3  4 | 5
- *    (SCL) 21   5  6 | 16 (TX2)
- *    (SDA) 20 | 7  8 | 17 (RX2)
- *    (RX1) 19 | 9 10 | 18 (TX1)
- *              ------
- *               SV1
- *
- *          SDCARD Header
- *              ------
- *      5V/3V3 | 1  2 | GND
- *       RESET | 3  4 | 38
- *   (MOSI) 51   5  6 | 40
- *     (SS) 53 | 7  8 | 42
- *    (SCK) 52 | 9 10 | 50 (MISO)
- *              ------
- *               SV3
+/**              LCD                             SDCARD
+ *              ------                           ------
+ *    (TX1) 18 | 1  2 | 19 (RX1)      (MISO) 50 | 1  2 | 52 (SCK)
+ *    (RX2) 17 | 3  4 | 20 (SDA)             42 | 3  4 | 53 (SS)
+ *    (TX2) 16 | 5  6   21 (SCL)             40 | 5  6   51 (MOSI)
+ *           5 | 7  8 |  6                   38 | 7  8 | RESET
+ *         GND | 9 10 | 5V                  GND | 9 10 | 5V/3V3
+ *              ------                           ------
+ *               SV1                              SV3
  *
  * GT2560 LCD & SD headers follow typical EXP1 & EXP2 format.
  * SD header voltage pin set by link pads beneath the header; R25 for 5V, R44 for 3.3V (default)
  * Pins 20 (SDA) and 21 (SCL) have external 10K pull-ups on the board.
  */
 
-#define SDSS                                  53
+#define EXP1_01_PIN                           18  // TX1 / BEEPER
+#define EXP1_02_PIN                           19  // RX1 / ENC
+#define EXP1_03_PIN                           17  // RX2 / CS
+#define EXP1_04_PIN                           20  // SDA / A0
+#define EXP1_05_PIN                           16  // TX2 / LCD_RS
+#define EXP1_06_PIN                           21  // SCL / CS
+#define EXP1_07_PIN                            5  // D6  / A0
+#define EXP1_08_PIN                            6  // D7  / D4
+
+#define EXP2_01_PIN                           50  // MISO
+#define EXP2_02_PIN                           52  // SCK
+#define EXP2_03_PIN                           42  // EN2
+#define EXP2_04_PIN                           53  // SDSS
+#define EXP2_05_PIN                           40  // EN1
+#define EXP2_06_PIN                           51  // MOSI
+#define EXP2_07_PIN                           38  // SD_DET
+#define EXP2_08_PIN                           -1  // RESET
+
+#define SDSS                         EXP2_04_PIN
 #define LED_PIN                               13
 
 #if HAS_WIRED_LCD
 
-  #define BEEPER_PIN                          18
+  #define BEEPER_PIN                 EXP1_01_PIN
 
   #if IS_NEWPANEL
 
     #if ENABLED(MKS_MINI_12864)
-      #define DOGLCD_A0                        5
-      #define DOGLCD_CS                       21
-      #define BTN_EN1                         40
-      #define BTN_EN2                         42
+      #define DOGLCD_CS              EXP1_06_PIN
+      #define DOGLCD_A0              EXP1_07_PIN
+      #define BTN_EN1                EXP2_05_PIN
+      #define BTN_EN2                EXP2_03_PIN
     #elif ENABLED(FYSETC_MINI_12864)
       // Disconnect EXP2-1 and EXP2-2, otherwise future firmware upload won't work.
-      #define DOGLCD_A0                       20
-      #define DOGLCD_CS                       17
+      #define DOGLCD_CS              EXP1_03_PIN
+      #define DOGLCD_A0              EXP1_04_PIN
 
-      #define NEOPIXEL_PIN                    21
-      #define BTN_EN1                         42
-      #define BTN_EN2                         40
+      #define NEOPIXEL_PIN           EXP1_06_PIN
+      #define BTN_EN1                EXP2_03_PIN
+      #define BTN_EN2                EXP2_05_PIN
 
-      #define LCD_RESET_PIN                   16
+      #define LCD_RESET_PIN          EXP1_05_PIN
 
       #define LCD_CONTRAST_INIT              220
 
       #define LCD_BACKLIGHT_PIN               -1
     #else
-      #define LCD_PINS_RS                     20
-      #define LCD_PINS_EN                     17
-      #define LCD_PINS_D4                     16
-      #define LCD_PINS_D5                     21
-      #define LCD_PINS_D6                      5
-      #define LCD_PINS_D7                      6
-      #define BTN_EN1                         42
-      #define BTN_EN2                         40
+      #define LCD_PINS_RS            EXP1_04_PIN
+      #define LCD_PINS_EN            EXP1_03_PIN
+      #define LCD_PINS_D4            EXP1_05_PIN
+      #define LCD_PINS_D5            EXP1_06_PIN
+      #define LCD_PINS_D6            EXP1_07_PIN
+      #define LCD_PINS_D7            EXP1_08_PIN
+      #define BTN_EN1                EXP2_03_PIN
+      #define BTN_EN2                EXP2_05_PIN
     #endif
 
-    #define BTN_ENC                           19
-    #define SD_DETECT_PIN                     38
+    #define BTN_ENC                  EXP1_02_PIN
+    #define SD_DETECT_PIN            EXP2_07_PIN
 
   #else                                           // !IS_NEWPANEL
 
-    #define SHIFT_CLK_PIN                     38
-    #define SHIFT_LD_PIN                      42
-    #define SHIFT_OUT_PIN                     40
-    #define SHIFT_EN_PIN                      17
+    #define SHIFT_CLK_PIN            EXP2_07_PIN
+    #define SHIFT_LD_PIN             EXP2_03_PIN
+    #define SHIFT_OUT_PIN            EXP2_05_PIN
+    #define SHIFT_EN_PIN             EXP1_03_PIN
 
-    #define LCD_PINS_RS                       16
-    #define LCD_PINS_EN                        5
-    #define LCD_PINS_D4                        6
-    #define LCD_PINS_D5                       21
-    #define LCD_PINS_D6                       20
-    #define LCD_PINS_D7                       19
+    #define LCD_PINS_RS              EXP1_05_PIN
+    #define LCD_PINS_EN              EXP1_07_PIN
+    #define LCD_PINS_D4              EXP1_08_PIN
+    #define LCD_PINS_D5              EXP1_06_PIN
+    #define LCD_PINS_D6              EXP1_04_PIN
+    #define LCD_PINS_D7              EXP1_02_PIN
 
     #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
       #define BTN_ENC_EN             LCD_PINS_D7  // Detect the presence of the encoder

--- a/Marlin/src/pins/mega/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_A.h
@@ -128,7 +128,10 @@
 
 #define SDSS                                  53
 #define LED_PIN                               13
-#define POWER_MONITOR_VOLTAGE_PIN             0 // 0 for main, 1 for dedicated bed supply
+
+//Power monitoring pins - set to 0 for main VIN, 1 for dedicated bed supply rail.
+//Don't forget to enable POWER_MONITOR_VOLTAGE in Configuration_adv.h set POWER_MONITOR_VOLTS_PER_VOLT to 0.090909
+#define POWER_MONITOR_VOLTAGE_PIN             0
 
 #if HAS_WIRED_LCD
 

--- a/Marlin/src/pins/mega/pins_GT2560_REV_A_PLUS.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_A_PLUS.h
@@ -30,8 +30,6 @@
 
 #define BOARD_INFO_NAME "GT2560 Rev.A+"
 
-#include "pins_GT2560_REV_A.h"
+#define SERVO0_PIN  11
 
-#if DISABLED(BLTOUCH)
-  #define SERVO0_PIN  32
-#endif
+#include "pins_GT2560_REV_A.h"

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -114,15 +114,15 @@
 #define USB_CONNECT_INVERTING              false
 
 /**
- *        SKR Mini E3 V1.0, V1.2
- *                ------
+ *         SKR Mini E3 V1.0, V1.2
+ *                 ------
  * (BEEPER)  PB5  | 1  2 | PB6 (BTN_ENC)
  * (BTN_EN1) PA9  | 3  4 | RESET
  * (BTN_EN2) PA10   5  6 | PB9  (LCD_D4)
  * (LCD_RS)  PB8  | 7  8 | PB7  (LCD_EN)
  *            GND | 9 10 | 5V
- *                ------
- *                 EXP1
+ *                 ------
+ *                  EXP1
  */
 #ifndef EXP1_02_PIN
   #define EXP1_02_PIN                       PB6

--- a/Marlin/src/pins/stm32f1/pins_KEDI_CONTROLLER_V1_2.h
+++ b/Marlin/src/pins/stm32f1/pins_KEDI_CONTROLLER_V1_2.h
@@ -190,7 +190,7 @@
     #define BTN_EN1                  EXP1_08_PIN
     #define BTN_EN2                  EXP1_06_PIN
 
-    #define LCD_PINS_ENABLE          EXP1_03_PIN
+    #define LCD_PINS_EN              EXP1_03_PIN
     #define LCD_PINS_D4              EXP1_05_PIN
 
   #elif IS_TFTGLCD_PANEL
@@ -211,7 +211,7 @@
     #define BTN_EN1                  EXP2_08_PIN
     #define BTN_EN2                  EXP2_06_PIN
 
-    #define LCD_PINS_ENABLE          EXP1_08_PIN
+    #define LCD_PINS_EN              EXP1_08_PIN
 
     #if ENABLED(FYSETC_MINI_12864)
 


### PR DESCRIPTION
### Description

Updates GT2560 Rev A/A+ pin definitions in the following ways:

- Always set SERVO0_PIN on Rev A+. That is not a BLTouch pin, it is a general servo pin, labeled as such on the board, and hooked to a PWM-enabled pin.
- Accommodate existing SERVO0 logic on existing Rev A boards. No one's setup should break unless they were adding custom #defines somewhere.
- Allow arbitrary SERVO0 definitions for Rev A (non-plus) boards; say, in Configuration.h. The manufacturer suggests soldering a 3-pin header in place of the ZMAX endstop connector, but that's not the only or even best option.
- Added diagram of LCD & SD headers, which many other pin files have, plus board-specific details on their use.
- Fixed PSU control pins; namely, this board has none at all. The former PS_ON_PIN is entirely disconnected in the schematic, and SUICIDE_PIN is actually one of two voltage monitoring pins that no one's been able to use until now.

### Requirements

Geeetech GT2560 Rev. A or A+

### Benefits

More accurate representation of the board's actual pinouts.

### Configurations

[Configuration.zip](https://github.com/DejitaruJin/Marlin/files/11583254/Configuration.zip)
